### PR TITLE
docs: add WFH hours tracker README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
-# microapp
-Test microapp
+# WFH Hours Tracker
+
+A simple Python microapp for recording work-from-home (WFH) hours to assist with Australian Taxation Office (ATO) tax claims.
+
+## Overview
+
+This project offers a lightweight command-line tool for logging your WFH sessions. Each session captures start and end times to calculate total hours worked at home, providing a clear record for tax-time reporting.
+
+## Getting Started
+
+1. Ensure [Python](https://www.python.org/) is installed on your system.
+2. Clone this repository.
+3. (Coming soon) Run the microapp with:
+   ```bash
+   python app.py
+   ```
+
+## Disclaimer
+
+This tool is intended to help with personal record keeping. Always consult official ATO guidelines or a tax professional when preparing your tax return.


### PR DESCRIPTION
## Summary
- add README describing Python microapp for tracking WFH hours for ATO tax claims

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6beb7ea6c8320a2a54e2b94cbc530