### PR TITLE
Add pywebview-based desktop GUI launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ This project provides a lightweight Flask web application for logging your WFH s
    ```
    The application will be available at [http://localhost:5000](http://localhost:5000).
 
+### Desktop GUI
+
+To launch the work log in a standalone desktop window, run:
+
+```bash
+python gui.py
+```
+
+This uses [pywebview](https://pywebview.flowrl.com/) to embed the existing Flask
+application in a minimal desktop window while keeping the same look and feel.
+
 ## Disclaimer
 
 This tool is intended to help with personal record keeping. Always consult official ATO guidelines or a tax professional when preparing your tax return.

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,21 @@
+import threading
+
+import webview
+
+from app import app
+
+
+def start_flask():
+    """Run the Flask development server."""
+    app.run(debug=False, use_reloader=False)
+
+
+def create_window():
+    """Start the GUI window with the running Flask app."""
+    webview.create_window("Tax Return FY25-26 Work Log", "http://127.0.0.1:5000")
+    webview.start()
+
+
+if __name__ == "__main__":
+    threading.Thread(target=start_flask, daemon=True).start()
+    create_window()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask>=3.0,<4
+pywebview>=4,<5


### PR DESCRIPTION
## Summary
- add `gui.py` to launch the existing Flask app inside a desktop window using pywebview
- include `pywebview` as dependency
- document desktop GUI usage in README

## Testing
- `pip install -r requirements.txt`
- `python gui.py` *(fails: You must have either QT or GTK with Python extensions installed in order to use pywebview)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ec971e1c8320ab228a2c47e6b090