### PR TITLE
Use thread-safe window destruction

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -25,7 +25,7 @@ class Api:
         if save and data:
             self.save_data(data)
         should_exit = True
-        window.destroy()
+        webview.destroy_window(window)
 
 
 def start_flask():


### PR DESCRIPTION
## Summary
- Replace direct window destruction with thread-safe `webview.destroy_window` in the GUI API

## Testing
- `python -m py_compile gui.py`
- `python gui.py` *(fails: ImportError: libXtst.so.6: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f1b57024832085b997c0dc138cb4